### PR TITLE
fix: Add id-token write permission to Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,6 +13,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## **Description**
This PR fixes the Claude Code Review GitHub Action workflow by adding the missing `id-token: write` permission. Without this permission, the OIDC token authentication was failing with "Bad credentials" errors, preventing the Claude Code Review action from running successfully.

---

## **Key Changes**
1. **GitHub Actions Permissions**: Added `id-token: write` permission to the workflow permissions block to enable OIDC token authentication.

---

## **Files Added**
None

---

## **Files Modified**
- **`.github/workflows/claude-review.yml`**: Added `id-token: write` permission to the `permissions` block (line 16) to fix OIDC authentication errors.

---

## **How to Test**
1. **Manual Testing:**
   - [ ] Create a new pull request to trigger the Claude Code Review workflow
   - [ ] Verify the workflow runs successfully without "Bad credentials" errors
   - [ ] Confirm that the Claude Code Review action can authenticate and post comments

2. **Automated Testing:**
   - The workflow will be tested automatically when this PR is merged and subsequent PRs are created
   - Monitor the workflow run logs to ensure OIDC authentication succeeds

---

## **Benefits**
- **CI/CD Stability**: Fixes authentication failures in the Claude Code Review workflow, ensuring automated code reviews can run successfully.
- **Developer Experience**: Removes friction from the PR review process by ensuring automated reviews work reliably.
- **Security**: Uses OIDC token-based authentication, which is more secure than long-lived credentials.

---

## **Screenshots (if applicable)**
_Not applicable for workflow configuration changes._

---

## **Related Issues**
- Fixes authentication errors in the Claude Code Review GitHub Action
- Related to GitHub's OIDC token authentication requirements for certain actions

---

## **Additional Notes**
The `id-token: write` permission is specifically required for GitHub Actions that use OIDC tokens to authenticate with external services. This is a standard permission required by many modern GitHub Actions that implement secure authentication patterns.

The workflow already had `contents: read`, `pull-requests: write`, and `issues: write` permissions, but was missing the `id-token: write` permission that the Claude Code Review action needs to authenticate properly.